### PR TITLE
fix: restore image support & file name fix

### DIFF
--- a/src/js/common/utils.ts
+++ b/src/js/common/utils.ts
@@ -28,7 +28,7 @@ export function getBookURL(url: URL): string | undefined {
  * @param path
  */
 export function extractPageImageURL(
-  request: chrome.webRequest.WebRequestBodyDetails // Changed type
+  request: chrome.webRequest.WebRequestBodyDetails | chrome.webRequest.WebResponseCacheDetails
 ): Promise<string | null> {
   const url = new URL(request.url);
 

--- a/src/js/eventPage/index.ts
+++ b/src/js/eventPage/index.ts
@@ -102,3 +102,27 @@ chrome.tabs.onUpdated.addListener(async function (tabId, changeInfo, tab) {
     chrome.action.setBadgeBackgroundColor({ color: "#f45752" });
   }
 });
+
+// Download ebook page images
+chrome.webRequest.onCompleted.addListener(
+  async function interceptPageResources(request) {
+    // Prevent event overloading
+    if (lastURL === request.url) return;
+    // Ignore requests made by the extension
+    if (request.initiator?.includes("chrome-extension://")) return;
+    lastURL = request.url;
+
+    // Attempt to fetch the underlying image URL (e.g. acquire base64 data urls, image urls, etc.)
+    const pageImageURL = await extractPageImageURL(request);
+    console.log(pageImageURL)
+    if (!pageImageURL) return;
+    try {
+      return await savePage(pageImageURL);
+    } catch (e) {
+      console.error(e);
+    }
+  },
+  {
+    urls: sites.map(site => site.pageResourceURLFilter)
+  }
+);

--- a/src/js/popup/pdf.ts
+++ b/src/js/popup/pdf.ts
@@ -57,10 +57,11 @@ export function createPDF(book: Book): Promise<jsPDF> {
         });
       }
 
-      // Generate simple filename
-      const bookId = book.url.split('/').pop()?.replace('docview/', '') || 'ebook';
+      // File name
       const pageCount = imagePages.length;
-      const filename = `${bookId}_${pageCount}pages`;
+      const activeTab = await getActiveTab();
+      const title = activeTab ? activeTab.title : book.url;
+      const filename = `${title}_${pageCount}pages.pdf`;
 
       pdf.save(filename);
       resolve(pdf);


### PR DESCRIPTION
## Description
Addresses a couple minor regressions from the recent major uplift [PR](https://github.com/janbaykara/ebook-scraper/pull/55):

- pages containing images were not being captured
- file names lacked pdf extension and had unintuitive naming (e.g. `reader.action_4pages`)