### PR TITLE
Add Support for Firefox

### DIFF
--- a/src/manifest/template.firefox.json
+++ b/src/manifest/template.firefox.json
@@ -1,0 +1,29 @@
+{
+  "name": "eBook Scraper",
+  "version": "[dynamically set by plugin]",
+  "description": "Save eBook pages as a PDF",
+  "manifest_version": 2,
+  "background": {
+    "scripts": ["js/background.js"]
+  },
+  "browser_action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "512": "icon-512.png"
+    }
+  },
+  "icons": {
+    "512": "icon-512.png",
+    "128": "icon-128.png",
+    "48": "icon-48.png",
+    "16": "icon-16.png"
+  },
+  "permissions": ["tabs", "storage", "webRequest", "webRequestBlocking"],
+  "content_scripts": [],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "ebook-scraper@ebook-scraper.com",
+      "strict_min_version": "109.0"
+    }
+  }
+}


### PR DESCRIPTION
Begun work on modifying build so it works on Firefox-based browsers. 

- Firefox only supports manifest V2 unlike Chrome's V3
- Made a new template.firefox.json for creating a V2 manifest for Firefox
- Will require env variables to be passed during dev builds, e.g. npm run build:firefox
- Various other changes to make manifest supported by Firefox, for example service_workers aren't supported, so a `scripts` array must be passed.

Will hopefully be able to work on this further.