### PR TITLE
Fix: remove root padding for popup

### DIFF
--- a/entrypoints/popup/App.css
+++ b/entrypoints/popup/App.css
@@ -1,6 +1,5 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
   text-align: center;
 }


### PR DESCRIPTION
Just a little fix to remove weird black border around popup caused by root padding. 

Tested the extension on both Chrome and Firefox and works well on both! 

Only issue noticed is the little number badge doesn't display on Firefox where it does on Chrome.